### PR TITLE
Exclude Dev Branch from Github Actions Runner

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -6,7 +6,15 @@ env:
   DATABASE_PASSWORD: password
 
 name: CI [Rubocop, Rspec, Brakeman]
-on: [push, pull_request]
+on: 
+  push:
+    branches:
+      - main
+      - test
+  pull_request:
+    branches:
+      - main
+      - test
 jobs:
   rspec-test:
     name: CI [Rubocop, Rspec, Brakeman]


### PR DESCRIPTION
## Work Done
Modified the workflow.yml to only enact actions on the ````main``` and ```test``` branches. This is as per our requirements, and also helps with our dev process.