### PR TITLE
tamu emails added as admin

### DIFF
--- a/app/controllers/student_logins/omniauth_callbacks_controller.rb
+++ b/app/controllers/student_logins/omniauth_callbacks_controller.rb
@@ -7,6 +7,11 @@ module StudentLogins
       if student_login.present?
         sign_out_all_scopes
         flash[:success] = t 'devise.omniauth_callbacks.success', kind: 'Google'
+        # Set admin status based on email
+        if student_login.email.ends_with?('@tamu.edu')
+          student_login.update(is_admin: true)
+        end
+
         sign_in_and_redirect student_login, event: :authentication
       else
         flash[:alert] = t 'devise.omniauth_callbacks.failure', kind: 'Google',

--- a/app/views/admin/dashboard/show.html.erb
+++ b/app/views/admin/dashboard/show.html.erb
@@ -83,8 +83,8 @@
       </div>
     </div>
   </div>
+  
 
-  <%= link_to "Sign Out", destroy_student_login_session_path %>
 </div>
 
 


### PR DESCRIPTION
### Temporary Fix for admin - student views:

Here’s what you will do:

1. Switch to the `fix_admin` branch.
2. Remove all `StudentLogin` and `Student` records from inside the Rails console using the following commands:
   ```ruby
   StudentLogin.destroy_all
   Student.destroy_all
   ```
3. Run the application with a TAMU email and a regular Gmail account:
   - The TAMU email should land you on the admin page.
   - The regular email should direct you to the student dashboard.
4. After that, check student creation in the Rails console again using:
   ```ruby
   StudentLogin.all
   Student.all
   ```

### Expected Results
- `StudentLogin.all` should show two accounts: one with `is_admin` set to `true` and the other with `is_admin` set to `false`.
- `Student.all` should show only one account with `is_admin` set to `false`.

