### PR TITLE
Prefill Degree Planner with Degree Requirements

### DIFF
--- a/app/controllers/degree_planners_controller.rb
+++ b/app/controllers/degree_planners_controller.rb
@@ -6,7 +6,16 @@ class DegreePlannersController < ApplicationController
     @default_plan = DegreeRequirement.includes(:course).where(major: @student.major)
 
     @student_courses = StudentCourse.includes(:course).where(student: @student).order(:sem)
+    if @student_courses.empty?
+      # Query the DegreeRequirements table based on the student's major_id
+      degree_requirements = DegreeRequirement.where(major_id: @student.major_id)
 
+      # Map the degree requirements to StudentCourse records
+      @student_courses = degree_requirements.map do |requirement|
+        StudentCourse.create(student: @student, course_id: requirement.course_id, sem: requirement.sem)
+      end
+    end
+    
     @plan_to_display = @student_courses.present? ? @student_courses : @default_plan
   end
 


### PR DESCRIPTION
## Work Done + Logic
When a user navigate to the degree planner, if the user's student_courses are empty, the controller queries the database for degree requirements matching the user's major. It then saves all of it to the user's student_courses table.

![image](https://github.com/user-attachments/assets/ebd73596-1646-45cd-a28d-a6ef8d4867c7)

## Todo
- [ ] Create a reset button to clear all courses, and prefill with the degree requirements again
- [ ] Create a clear button to clear all courses.